### PR TITLE
fix: BrowserDataContext typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ const htmlStream = renderToNodeStream(
 );
 ```
 
-On client side of application use `BroswerDataContext`:
+On client side of application use `BrowserDataContext`:
 
 ```js
 // This will create context will all data fetched during server side rendering
-const BroswerDataContext = createBroswerContext();
+const BrowserDataContext = createBrowserContext();
 
 hydrate(
-  <BroswerDataContext>
+  <BrowserDataContext>
     <App />
-  </BroswerDataContext>,
+  </BrowserDataContext>,
   document.getElementById("app")
 );
 ```
@@ -140,12 +140,12 @@ Both should be used in server side render function.
 
 ---
 
-### createBroswerContext()
+### createBrowserContext()
 
 Creates client side context.
 
 ```js
-createBroswerContext(variableName);
+createBrowserContext(variableName);
 ```
 
 #### params
@@ -156,12 +156,12 @@ createBroswerContext(variableName);
 
 #### returns
 
-`BroswerDataContext` - React context provider for client side application
+`BrowserDataContext` - React context provider for client side application
 
 ```html
-<BroswerDataContext>
+<BrowserDataContext>
   <App />
-</BroswerDataContext>
+</BrowserDataContext>
 ```
 
 ## Examples

--- a/example/Client.jsx
+++ b/example/Client.jsx
@@ -2,14 +2,14 @@ import React from "react";
 import { hydrate } from "react-dom";
 import App from "./App";
 import AppWithTimeout from "./AppWithTimeout";
-import { createBroswerContext } from "use-sse";
+import { createBrowserContext } from "use-sse";
 
-const BroswerDataContext = createBroswerContext();
+const BrowserDataContext = createBrowserContext();
 
 hydrate(
-  <BroswerDataContext>
+  <BrowserDataContext>
     <App />
     <AppWithTimeout />
-  </BroswerDataContext>,
+  </BrowserDataContext>,
   document.getElementById("app")
 );

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ npm start
 
 Go to `localhost:3000`.
 
-Expected output in broswer:
+Expected output in browser:
 
 ```
 Hello world from async API!

--- a/src/useSSE.tsx
+++ b/src/useSSE.tsx
@@ -92,7 +92,7 @@ export function useSSE<T>(
   return [data, error];
 }
 
-export const createBroswerContext = (
+export const createBrowserContext = (
   variableName: string = "_initialDataContext"
 ) => {
   const initial = window && window[variableName] ? window[variableName] : {};
@@ -101,7 +101,7 @@ export const createBroswerContext = (
     resolved: true,
     requests: [],
   };
-  function BroswerDataContext<T>(props: Props<T>) {
+  function BrowserDataContext<T>(props: Props<T>) {
     return (
       <InternalContext.Provider value={internalContextValue}>
         <DataContext.Provider value={initial}>
@@ -111,7 +111,7 @@ export const createBroswerContext = (
     );
   }
 
-  return BroswerDataContext;
+  return BrowserDataContext;
 };
 
 const wait = (time: number) => {


### PR DESCRIPTION
Hello 👋 

Thank you for this nice library!

This PR brings a typo fix for the `BrowserDataContext` object (previously named `BroswerDataContext`), with docs updated accordingly. I understand this name is first-class citizen in the API, so this change **is breaking**.

IMHO it may also make sense to rename `BrowserDataContext` to `ClientDataContext` directly, since the dual server provider is `ServerDataContext`. Let me know if this is something you'd prefer, I'll be happy to change this PR 🙂 

Cheers!